### PR TITLE
Fix custom write function segfault

### DIFF
--- a/python/src/fastfec/utils.py
+++ b/python/src/fastfec/utils.py
@@ -21,7 +21,7 @@ SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 PARENT_DIR = pathlib.Path(SCRIPT_DIR).parent.absolute()
 
 # Buffer constants
-BUFFER_SIZE = 4096
+BUFFER_SIZE = 1024 * 1024
 
 # Callback function ctypes
 BUFFER_READ = CFUNCTYPE(c_size_t, POINTER(c_char), c_int, c_void_p)

--- a/python/src/fastfec/utils.py
+++ b/python/src/fastfec/utils.py
@@ -25,7 +25,7 @@ BUFFER_SIZE = 1024 * 1024
 
 # Callback function ctypes
 BUFFER_READ = CFUNCTYPE(c_size_t, POINTER(c_char), c_int, c_void_p)
-CUSTOM_WRITE = CFUNCTYPE(None, c_char_p, c_char_p, c_char_p, c_int)
+CUSTOM_WRITE = CFUNCTYPE(None, c_char_p, c_char_p, POINTER(c_char), c_int)
 CUSTOM_LINE = CFUNCTYPE(None, c_char_p, c_char_p, c_char_p)
 
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -37,3 +37,10 @@ def filing_1550548(get_fixture):
     Returns the file path for 1550548.fec
     """
     return get_fixture("1550548.fec")
+
+@pytest.fixture
+def filing_1606847(get_fixture):
+    """
+    Returns the file path for 1606847.fec
+    """
+    return get_fixture("1606847.fec")

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -85,3 +85,31 @@ def test_filing_1550548_parse_as_files(tmpdir, filing_1550548):
 
     with open(os.path.join(tmpdir, "SB23.csv")) as filing:
         assert len(filing.readlines()) == 36
+
+
+def test_filing_1606847_parse_as_files(tmpdir, filing_1606847):
+    """
+    Test that the FastFEC `parse_as_files` method outputs the correct files
+    and that they do not SEGFAULT.
+    """
+    with open(filing_1606847, "rb") as filing:
+        with FastFEC() as fastfec:
+            fastfec.parse_as_files(filing, tmpdir)
+
+    assert (
+        os.listdir(tmpdir).sort()
+        == [
+            "SA11AI.csv",
+            "TEXT.csv",
+            "SB29.csv",
+            "SB22.csv",
+            "SA15.csv",
+            "SA12.csv",
+            "header.csv",
+            "SB28A.csv",
+            "SB21B.csv",
+            "SA11C.csv",
+            "SA17.csv",
+            "F3XA.csv",
+        ].sort()
+    )


### PR DESCRIPTION
Addresses [this issue](https://github.com/washingtonpost/FastFEC/issues/29).

We call client.py via `parse_as_files_custom`.

In turn `parse_as_files_custom` takes an argument, `open_function`, and passes it in to `utils.provide_write_callback`, which handles writing to various files and uses `open_function` to create new file handles for various files.

`utils.provide_write_callback` uses a type-factory from `ctypes` and deems it the `CUSTOM_WRITE` type.

`CUSTOM_WRITE` represents, on the C side of things, `CustomWriteFunction`.

```
CUSTOM_WRITE = CFUNCTYPE(None, c_char_p, c_char_p, POINTER(c_char), c_int)

...

typedef void (*CustomWriteFunction)(char *filename, char *extension, char *contents, int numBytes);
```

But! Calling any python `CustomWriteFunction` induces a `SEGFAULT`!

So, I wrote a `CustomWriteFunction` in C, and passed that in. This, and some heavy `printf`-debugging, led me to notice that `contents` is not a `NULL`-terminated `char*`. That made me wonder if somewhere along the way, there was machinery in `ctypes` that assumed it _was_, since `NULL`-terminated `char*`s are the defacto `str` type in C-land.

It turns out, in the [docs for `ctypes.c_char_p`](https://docs.python.org/3/library/ctypes.html#ctypes.c_char_p), we're told that `c_char_p`:
> Represents the C char* datatype when it points to a zero-terminated string. For a general character pointer that may also point to binary data, POINTER(c_char) must be used. The constructor accepts an integer address, or a bytes object.

Doing so means that calls to:
```
#! python

import smart_open
from fastfec import *


if __name__ == "__main__":
    headers = {'headers': {'User-Agent': 'Mozilla/5.0'}}
    with smart_open.open(f'http://docquery.fec.gov/dcdev/posted/1606847.fec', 'rb', transport_params=headers) as f:
        with FastFEC() as fastfec:
            fastfec.parse_as_files(f, "some_output_directory", include_filing_id='1606847')
```
no longer `SEGFAULT`.