### PR TITLE
Revert "Change return to have 0 as healthy and 1 as error"

### DIFF
--- a/python/src/fastfec/client.py
+++ b/python/src/fastfec/client.py
@@ -173,7 +173,7 @@ class LibFastFEC:
         self.libfastfec.freeFecContext(fec_context)
         free_file_descriptors()
 
-        if result == 1:
+        if result == -1:
             raise Exception("FastFEC failed to parse.")
 
         return result

--- a/src/fec.c
+++ b/src/fec.c
@@ -94,7 +94,7 @@ int lookupMappings(FEC_CONTEXT *ctx, PARSE_CONTEXT *parseContext, int formStart,
   if ((ctx->formType != NULL) && (strncmp(ctx->formType, parseContext->line->str + formStart, formEnd - formStart) == 0))
   {
     // Type mappings are unchanged from before; can return early
-    return 0;
+    return 1;
   }
 
   // Clear last form type information if present
@@ -183,14 +183,14 @@ int lookupMappings(FEC_CONTEXT *ctx, PARSE_CONTEXT *parseContext, int formStart,
         freeString(headersCsv);
 
         // Done; return
-        return 0;
+        return 1;
       }
     }
   }
 
   // Unmatched — error
   fprintf(stderr, "Error: Unmatched for version %s and form type %s\n", ctx->version, ctx->formType);
-  return 1;
+  return -1;
 }
 
 void writeSubstrToWriter(FEC_CONTEXT *ctx, WRITE_CONTEXT *writeContext, char *filename, const char *extension, int start, int end, FIELD_INFO *field)
@@ -545,8 +545,8 @@ int parseLine(FEC_CONTEXT *ctx, char *filename, int headerRow)
       int mappings = lookupMappings(ctx, &parseContext, formStart, formEnd);
 
       // Failed to find a match; skip this filing
-      if (mappings == 1) {
-        return 1;
+      if (mappings == -1) {
+        return -1;
       }
 
       // Set filename if null to form type
@@ -863,8 +863,8 @@ int parseFec(FEC_CONTEXT *ctx)
     
     skipGrabLine = parseLineResult == 2;
 
-    if (parseLineResult == 1) {
-      return 1;
+    if (parseLineResult == -1) {
+      return -1;
       }
   }
 


### PR DESCRIPTION
Turns out this small change was broken. Gonna revert to the slightly worse, but working version, to unblock [this PR](https://github.com/actblue/fastfec-parser/pull/44) and leave making it both Good and Working in [this ticket](https://actblue.atlassian.net/browse/DENG-148?atlOrigin=eyJpIjoiOTMxMmJmN2UwMWZhNGE4MDhjN2ZmZDUxNzIwNWVkYmIiLCJwIjoiaiJ9)