### PR TITLE
Potential fix for code scanning alert no. 26: Potentially unsafe use of strcat

### DIFF
--- a/src/writer.c
+++ b/src/writer.c
@@ -217,18 +217,31 @@ int getFile(WRITE_CONTEXT *context, char *filename, const char *extension)
   if (context->writeToFile)
   {
     // Ensure the directory exists (will silently fail if it does)
-    char *fullpath = (char *)malloc(sizeof(char) * (strlen(context->outputDirectory) + strlen(filename) + 1 + strlen(context->filingId) + strlen(extension) + 1));
-    strcpy(fullpath, context->outputDirectory);
-    strcat(fullpath, context->filingId);
+    size_t fullpath_len = strlen(context->outputDirectory) + strlen(context->filingId) + strlen(DIR_SEPARATOR)
+        + strlen(filename) + strlen(extension) + 1;
+    char *fullpath = (char *)malloc(fullpath_len);
+    if (!fullpath) {
+        // Handle malloc failure
+        free(normalizedFilename);
+        return -1;
+    }
+
+    fullpath[0] = '\0';
+    strncat(fullpath, context->outputDirectory, fullpath_len - strlen(fullpath) - 1);
+    strncat(fullpath, context->filingId, fullpath_len - strlen(fullpath) - 1);
     mkdir_p(fullpath);
 
     // Add the normalized filename to path
-    strcat(fullpath, DIR_SEPARATOR);
+    strncat(fullpath, DIR_SEPARATOR, fullpath_len - strlen(fullpath) - 1);
     char *normalizedFilename = malloc(strlen(filename) + 1);
-    strcpy(normalizedFilename, filename);
+    if (!normalizedFilename) {
+        free(fullpath);
+        return -1;
+    }
+    strncpy(normalizedFilename, filename, strlen(filename) + 1);
     normalize_filename(normalizedFilename);
-    strcat(fullpath, normalizedFilename);
-    strcat(fullpath, extension);
+    strncat(fullpath, normalizedFilename, fullpath_len - strlen(fullpath) - 1);
+    strncat(fullpath, extension, fullpath_len - strlen(fullpath) - 1);
 
     context->files[context->nfiles] = fopen(fullpath, "w");
     // Free the derived file paths


### PR DESCRIPTION
Potential fix for [https://github.com/actblue/FastFEC/security/code-scanning/26](https://github.com/actblue/FastFEC/security/code-scanning/26)

To fix the buffer overflow risk when constructing `fullpath`, we should replace all uses of `strcat` and `strcpy` with their bounded equivalents (`strncat` and `strncpy`) and carefully check the buffer size at each step. A robust approach is to ensure all appended strings together never exceed the declared capacity of `fullpath`. Each time we copy or append a string, we should track the current length and only allow as many bytes as will fit before the buffer's end, always reserving space for the null terminator. If at any point the total would exceed the allocation, we should handle the error gracefully (e.g., log and abort). All these changes should be made in the region from lines 220–236 in `src/writer.c`, updating the string operations for `fullpath`. No additional library imports are required; `strncpy` and `strncat` are available via `<string.h>`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
